### PR TITLE
solana: add ability to skip module build

### DIFF
--- a/solana/Makefile
+++ b/solana/Makefile
@@ -39,7 +39,9 @@ cargo-test: fast-transfer-sync
 
 .PHONY: anchor-test
 anchor-test: node_modules $(CLONED_PROGRAMS)
+ifndef SKIP_SUBMODULE_BUILD
 	cd .. && $(MAKE) fast-transfer-setup
+endif
 	anchor test -- --features integration-test
 
 .PHONY: cargo-test-all


### PR DESCRIPTION
```sh
SKIP_SUBMODULE_BUILD=1 make anchor-test
```