### PR TITLE
EVM: Add CI testing

### DIFF
--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -1,0 +1,31 @@
+name: evm 
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'evm/**'
+  push:
+    branches:
+      - main
+env:
+  FOUNDRY_PROFILE: ci
+jobs:
+  test:
+    strategy:
+      fail-fast: true
+    name: forge test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Run Forge build
+        working-directory: evm
+        run: make build 
+      - name: Run unit tests
+        working-directory: evm
+        run: make test 

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -4,7 +4,9 @@ on:
     branches:
       - main
       - solana/integration
-  pull_request: null
+  pull_request:
+    paths:
+      - 'solana/**' 
 
 env:
   RUSTC_VERSION: 1.75.0

--- a/.github/workflows/universal-rs.yml
+++ b/.github/workflows/universal-rs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - 'universal/**'
 
 env:
   CARGO_TERM_COLOR: always

--- a/evm/package.json
+++ b/evm/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@xlabs.xyz/swap-layer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "startLocalBaseSepolia": "anvil --fork-url https://sepolia.base.org --port 8546",
+    "startLocalArbitrumSepolia": "anvil --fork-url https://public.stackup.sh/api/v1/node/arbitrum-sepolia --port 8547",
+    "startLocalFuji": "anvil --fork-url https://api.avax-test.network/ext/bc/C/rpc --port 8548",
+    "deployLocalTestnet": "ENV=localTestnet sh ./ts-scripts/shell/deploySwapLayer.sh",
+    "configureLocalTestnet": "ENV=localTestnet sh ./ts-scripts/shell/configureSwapLayer.sh",
+    "updateFeesLocalTestnet": "ENV=localTestnet sh ./ts-scripts/shell/updateFeesSwapLayer.sh",
+    "runAllLocalTestnet": "ENV=localTestnet sh ./ts-scripts/shell/fullDeployAndConfigure.sh",
+    "runAllTestnet": "ENV=testnet sh ./ts-scripts/shell/fullDeployAndConfigure.sh",
+    "testRegularSendTestnet": "ENV=testnet sh ./ts-scripts/shell/testRegularSend.sh",
+    "testRegularSendLocal": "ENV=localTestnet sh ./ts-scripts/shell/testRegularSend.sh",
+    "testFastSendTestnet": "ENV=testnet sh ./ts-scripts/shell/testFastSend.sh",
+    "deployTestnet": "ENV=testnet sh ./ts-scripts/shell/deploySwapLayer.sh",
+    "configureTestnet": "ENV=testnet sh ./ts-scripts/shell/configureSwapLayer.sh",
+    "spy:testnet": "docker run --platform=linux/amd64 -p 7073:7073 --entrypoint /guardiand ghcr.io/wormhole-foundation/guardiand:latest spy --nodeKey /node.key --spyRPC \"[::]:7073\" --network /wormhole/testnet/2/1 --bootstrap /dns4/wormhole-testnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWAkB9ynDur1Jtoa97LBUp8RXdhzS5uHgAfdTquJbrbN7i",
+    "spy:mainnet": "docker run --platform=linux/amd64 -p 7073:7073 --entrypoint /guardiand ghcr.io/wormhole-foundation/guardiand:latest spy --nodeKey /node.key --spyRPC \"[::]:7073\" --network /wormhole/mainnet/2 --bootstrap /dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7,/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8999/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC",
+    "build": "make build && npx typechain --target=ethers-v5 --out-dir=./ethers-contracts `find ./out/ -name \"*.json\"` --show-stack-traces"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@certusone/wormhole-sdk": "^0.10.3",
+    "@openzeppelin/contracts": "^4.9.3",
+    "@typechain/ethers-v5": "^11.1.1",
+    "@wormhole-foundation/connect-sdk": "^0.4.0-beta.0",
+    "@wormhole-foundation/connect-sdk-evm": "^0.4.0-beta.0",
+    "@wormhole-foundation/relayer-engine": "github:wormhole-foundation/relayer-engine#e3c510048ef8c900769461040440b689a18d9e0d",
+    "@xlabs/wh-swap-layer-ts-sdk": "file:ts-sdk",
+    "dotenv": "^16.3.1",
+    "ts-node": "^10.9.1",
+    "tsx": "^4.7.0",
+    "typechain": "^8.1.1",
+    "typescript": "^5.2.2"
+  }
+}


### PR DESCRIPTION
Rebase of `solana/integration` onto main resulted in the `evm/package.json` being deleted, this restores that file with its scripts

- [ ] add github action for evm testing