### PR TITLE
solana: clean up initialize

### DIFF
--- a/solana/programs/swap-layer/src/error.rs
+++ b/solana/programs/swap-layer/src/error.rs
@@ -31,6 +31,7 @@ pub enum SwapLayerError {
     PayloadTooLarge = 0x114,
     UnsupportedFillType = 0x115,
     SwapTimeLimitNotExceeded = 0x116,
+    ImmutableProgram = 0x118,
 
     // EVM Execution Param errors
     InvalidBaseFee = 0x200,

--- a/solana/ts/src/swapLayer/index.ts
+++ b/solana/ts/src/swapLayer/index.ts
@@ -19,6 +19,7 @@ import IDL from "../../../target/idl/swap_layer.json";
 import { SwapLayer } from "../../../target/types/swap_layer";
 import { OutputToken, encodeOutputToken } from "./messages";
 import { Custodian, Peer, RedeemOption, RelayParams, StagedInbound, StagedOutbound } from "./state";
+import { programDataAddress } from "./utils";
 
 export const PROGRAM_IDS = ["SwapLayer1111111111111111111111111111111111"] as const;
 
@@ -299,7 +300,7 @@ export class SwapLayerProgram {
                     feeRecipient,
                 ),
                 feeUpdater,
-                usdc: this.usdcComposite(),
+                programData: programDataAddress(this.ID),
                 systemProgram: SystemProgram.programId,
             })
             .instruction();


### PR DESCRIPTION
NOTE: The upgrade authority and owner do not have to be the same key after `initialize` is called. But this instruction requires that the one who deployed the program is the one that initializes it.

Closes #33.